### PR TITLE
Adding backtrace to Honeybadger notification

### DIFF
--- a/cme.thor
+++ b/cme.thor
@@ -20,7 +20,7 @@ class CmeThor < Thor
     exit
   rescue => e
     Logging.logger.error { "Uncaught CME Exception: #{e.message}" }
-    Honeybadger.notify(error_class: e, error_message: "Uncaught CME Exception: #{e.message}")
+    Honeybadger.notify(error_class: e, error_message: "Uncaught CME Exception: #{e.message}", backtrace: e.backtrace)
     kill_all_threads
     retry
   end


### PR DESCRIPTION
We get errors thrown in to Honeybadger often, unfortunately unable to get the backtrace to see where it originated from. This PR will add backtrace to Honeybadger API.