### PR TITLE
New Connection with History

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ WORKDIR /usr/src/app
 
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
-RUN bundle install
+RUN bundle install --without development test
 
 COPY . /usr/src/app

--- a/Gemfile
+++ b/Gemfile
@@ -17,11 +17,11 @@ gem "thor"
 
 group :test do
   gem "rspec"
+  gem "rspec_junit_formatter"
 end
 
 group :development, :test do
   gem "pry"
   gem "pry-nav"
   gem "pry-rescue"
-  gem "rspec_junit_formatter"
 end

--- a/lib/cme_fix_listener/request_generator.rb
+++ b/lib/cme_fix_listener/request_generator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/testing/time_helpers"
 module CmeFixListener
   # Builds a valid trade capture report request xml message required by CME.
   class RequestGenerator
@@ -16,9 +17,10 @@ module CmeFixListener
     end
 
     def build_xml(request_type)
+      params = initial_history(request_type)
       Nokogiri::XML::Builder.new do |xml|
         xml.FIXML(fixml_attrs) do
-          xml.TrdCaptRptReq(trd_cpt_rpt_request_attrs(request_type)) do
+          xml.TrdCaptRptReq(trd_cpt_rpt_request_attrs(request_type).merge(params)) do
             xml.Hdr(header_attrs)
             xml.Pty(party_attrs)
           end
@@ -27,6 +29,14 @@ module CmeFixListener
     end
 
     protected
+
+    def initial_history(request_type)
+      return {} if request_type != "1"
+      start_time = Time.now - 1.hour
+      {
+        "StartTm" => start_time.to_s(:iso8601)
+      }
+    end
 
     def generator_type
       "REGULAR"

--- a/spec/cme_fix_listener/request_generator_spec.rb
+++ b/spec/cme_fix_listener/request_generator_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 describe CmeFixListener::RequestGenerator do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:klass) { described_class }
   let(:instance) { klass.new(account) }
   let(:content_type) { "text/xml" }
@@ -26,7 +28,12 @@ describe CmeFixListener::RequestGenerator do
 
     context "initial subscription" do
       let(:file_name) { "trading_firm_initial_subscription.xml" }
-      it { expect(instance.build_xml("1")).to eq message_spec_xml }
+      let(:some_point_in_time) { Time.parse("2013-10-22T12:00:00-05:00") }
+      it "builds xml for initial request with hour of history" do
+        travel_to(some_point_in_time) do
+          expect(instance.build_xml("1")).to eq message_spec_xml
+        end
+      end
     end
 
     context "continued subscription" do

--- a/spec/datafiles/trading_firm_initial_subscription.xml
+++ b/spec/datafiles/trading_firm_initial_subscription.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <FIXML v="5.0 SP2" s="20090815" xv="109" cv="CME.0001">
-  <TrdCaptRptReq ReqID="DEVELOPMENT-400-REGULAR-COMPANY_NAME" ReqTyp="1" SubReqTyp="1" MLegRptTyp="3">
+  <TrdCaptRptReq ReqID="DEVELOPMENT-400-REGULAR-COMPANY_NAME" ReqTyp="1" SubReqTyp="1" MLegRptTyp="3" StartTm="2013-10-22T11:00:00-05:00">
     <Hdr SID="COMPANY_SPEC" TID="CME" SSub="USERNAME_SPEC" TSub="STP"/>
     <Pty ID="COMPANY_SPEC" R="7"/>
   </TrdCaptRptReq>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Bundler.require(:default)
+Bundler.require(:default, :test)
 require "active_support/all"
 require_all "lib"
 


### PR DESCRIPTION
On connecting if existing session is not found, send a StartTm tag with an hour ago timestamp. This will mitigate missing trade issues.