### PR TITLE
Updating app deployment gitlab-ci.yml templates, updating README, displaying test report

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -29,13 +29,13 @@ jobs:
         REDIS_PORT: ${{ job.services.redis.ports[6379] }}
         TZ: "America/Chicago"
       run: |
-        mkdir -p /tmp/test-results
+        mkdir -p test-results
         TEST_FILES=
 
-        bundle exec rspec --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+        bundle exec rspec --format progress --format RspecJunitFormatter --out test-results/rspec.xml
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         files: |
-          /tmp/test-results/rspec.xml
+          test-results/rspec.xml

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,4 +32,10 @@ jobs:
         mkdir -p /tmp/test-results
         TEST_FILES=
 
-        bundle exec rspec --format progress
+        bundle exec rspec --format progress --format RspecJunitFormatter --out /tmp/test-results/rspec.xml
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: |
+          /tmp/test-results/rspec.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,17 @@ include:
   - project: 'wearemolecule/gitlab-templates'
     ref: master
     file: 'docker-build-template.yaml'
+  - project: 'wearemolecule/gitlab-templates'
+    ref: master
+    file: 'vapor-kustomize-deployment.yaml'  
 
 stages:
   - test
   - build
   - deploy
+
+variables:
+  NO_DEPLOY: 'true'
 
 # Cache modules in between jobs
 cache:
@@ -23,7 +29,7 @@ tests:
   image: ruby:3.0.3
   retry: 1
   services:
-    - redis:4.0-stretch
+    - redis:7-alpine
   variables:
     TZ: "America/Chicago"
   script:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 # CME STP Adapter
 
 [![GitHub Actions](https://github.com/wearemolecule/cme-fix-listener/actions/workflows/actions.yaml/badge.svg)](https://github.com/wearemolecule/cme-fix-listener/actions)
-[![Docker Repository on Quay](https://quay.io/repository/molecule/cme-fix-listener/status "Docker Repository on Quay")](https://quay.io/repository/molecule/cme-fix-listener)
 
 A service that connects to the [CME's Straight Through Processing API](http://www.cmegroup.com/confluence/display/EPICSANDBOX/CME+STP) to download trades in FIXML format, and returns easy-to-read, JSON-formatted trades.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Molecule Software](https://avatars1.githubusercontent.com/u/2736908?v=3&s=100 "Molecule Software")
 # CME STP Adapter
 
-[![GitHub Actions](https://github.com/wearemolecule/cme-fix-listener/actions/workflows/actions.yml/badge.svg)](https://github.com/wearemolecule/cme-fix-listener/actions)
+[![GitHub Actions](https://github.com/wearemolecule/cme-fix-listener/actions/workflows/actions.yaml/badge.svg)](https://github.com/wearemolecule/cme-fix-listener/actions)
 [![Docker Repository on Quay](https://quay.io/repository/molecule/cme-fix-listener/status "Docker Repository on Quay")](https://quay.io/repository/molecule/cme-fix-listener)
 
 A service that connects to the [CME's Straight Through Processing API](http://www.cmegroup.com/confluence/display/EPICSANDBOX/CME+STP) to download trades in FIXML format, and returns easy-to-read, JSON-formatted trades.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Molecule Software](https://avatars1.githubusercontent.com/u/2736908?v=3&s=100 "Molecule Software")
 # CME STP Adapter
 
-[![CircleCI](https://circleci.com/gh/wearemolecule/cme-fix-listener.svg?style=svg)](https://circleci.com/gh/wearemolecule/cme-fix-listener)
+[![GitHub Actions](https://github.com/wearemolecule/cme-fix-listener/actions/workflows/actions.yml/badge.svg)](https://github.com/wearemolecule/cme-fix-listener/actions)
 [![Docker Repository on Quay](https://quay.io/repository/molecule/cme-fix-listener/status "Docker Repository on Quay")](https://quay.io/repository/molecule/cme-fix-listener)
 
 A service that connects to the [CME's Straight Through Processing API](http://www.cmegroup.com/confluence/display/EPICSANDBOX/CME+STP) to download trades in FIXML format, and returns easy-to-read, JSON-formatted trades.


### PR DESCRIPTION
This PR updates the gitlab-ci.yml templates Molecule uses.

It also updates the badges used in the README, since we switched from circle ci to github actions.

Finally, this PR displays test coverage in MRs and as a separate result on Actions.