### PR TITLE
[OME-437] [URGENT] Handle invalid x-cme-token by clearing token and re-subscribing

### DIFF
--- a/lib/cme_fix_listener/response_handler.rb
+++ b/lib/cme_fix_listener/response_handler.rb
@@ -62,8 +62,13 @@ module CmeFixListener
     end
 
     def handle_error(parser, body)
-      notify_admins_of_error(CmeResponseHasErrors, body_error_message, body_error_context(parser, body))
-      @body_has_errors = true
+      if invalid_token?(parser.request_acknowledgement_text.downcase)
+        Logging.logger.warn { "Invalid x-cme-token for account #{account_id}. Clearing token to initiate new subscription." }
+        CmeFixListener::TokenManager.clear_token_for_account(@account_id)
+      else
+        notify_admins_of_error(CmeResponseHasErrors, body_error_message, body_error_context(parser, body))
+        @body_has_errors = true
+      end
       nil
     end
 

--- a/lib/cme_fix_listener/token_manager.rb
+++ b/lib/cme_fix_listener/token_manager.rb
@@ -15,6 +15,12 @@ module CmeFixListener
       end
     end
 
+    def self.clear_token_for_account(account_id)
+      catch_errors("delete") do
+        Resque.redis.del(key_name(account_id))
+      end
+    end
+
     def self.key_name(account_id)
       "cme-token-#{account_id}"
     end

--- a/lib/mixins/error_notifier_methods.rb
+++ b/lib/mixins/error_notifier_methods.rb
@@ -41,4 +41,8 @@ module ErrorNotifierMethods
   def query_error_message
     "Request ID or Party Role most likely not set correctly"
   end
+
+  def invalid_token?(error_txt)
+    (error_txt =~ /no longer valid/).present?
+  end
 end

--- a/spec/cme_fix_listener/response_handler_spec.rb
+++ b/spec/cme_fix_listener/response_handler_spec.rb
@@ -3,8 +3,7 @@
 require "spec_helper"
 
 describe CmeFixListener::ResponseHandler do
-  let(:klass) { described_class }
-  let(:instance) { klass.new(account) }
+  let(:instance) { described_class.new(account) }
   let(:account) { { "id" => 123 } }
   let(:time_zone) { "Central Time (US & Canada)" }
   let(:token_manager_klass) { CmeFixListener::TokenManager }
@@ -90,6 +89,64 @@ describe CmeFixListener::ResponseHandler do
       it "should short circuit" do
         expect_any_instance_of(parser_klass).to receive(:parse_fixml).and_return("return")
         expect(subject).to eq "return"
+      end
+    end
+  end
+
+  describe "#handle_error" do
+    let(:parser) { instance_double(parser_klass, request_acknowledgement_text: error_text) }
+
+    subject { instance.handle_error(parser, "body") }
+
+    context "when the error is an invalid token" do
+      let(:error_text) { "x-cme-token is no longer valid. Please initiate a new subscription" }
+
+      it "clears the token from Redis" do
+        expect(token_manager_klass).to receive(:clear_token_for_account).with(123)
+        subject
+      end
+
+      it "does not notify Honeybadger" do
+        allow(token_manager_klass).to receive(:clear_token_for_account)
+        expect(Honeybadger).not_to receive(:notify)
+        subject
+      end
+
+      it "does not set body_has_errors" do
+        allow(token_manager_klass).to receive(:clear_token_for_account)
+        subject
+        expect(instance.experiencing_problems?).to eq false
+      end
+
+      it "returns nil" do
+        allow(token_manager_klass).to receive(:clear_token_for_account)
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when the error is a different CME error" do
+      let(:error_text) { "not entitled to query" }
+
+      it "notifies Honeybadger" do
+        expect(Honeybadger).to receive(:notify)
+        subject
+      end
+
+      it "sets body_has_errors" do
+        allow(Honeybadger).to receive(:notify)
+        subject
+        expect(instance.experiencing_problems?).to eq true
+      end
+
+      it "does not clear the token" do
+        allow(Honeybadger).to receive(:notify)
+        expect(token_manager_klass).not_to receive(:clear_token_for_account)
+        subject
+      end
+
+      it "returns nil" do
+        allow(Honeybadger).to receive(:notify)
+        expect(subject).to be_nil
       end
     end
   end

--- a/spec/cme_fix_listener/token_manager_spec.rb
+++ b/spec/cme_fix_listener/token_manager_spec.rb
@@ -6,11 +6,10 @@ require "redis_test_helpers"
 describe CmeFixListener::TokenManager do
   include RedisTestHelpers
 
-  let(:klass) { described_class }
   let(:account) { { "id" => 123 } }
 
   describe ".last_token_for_account", redis: true do
-    subject { klass.last_token_for_account(account["id"]) }
+    subject { described_class.last_token_for_account(account["id"]) }
     before { Resque.redis.rpush("cme-token-123", "123abc") }
 
     it { expect(subject).to eq "123abc" }
@@ -26,7 +25,7 @@ describe CmeFixListener::TokenManager do
 
   describe ".add_token_for_account", redis: true do
     let(:header) { { "token" => "token", "account_id" => "123" } }
-    subject { klass.add_token_for_account(header) }
+    subject { described_class.add_token_for_account(header) }
 
     it "redis hsould have the correct members" do
       subject
@@ -42,8 +41,26 @@ describe CmeFixListener::TokenManager do
     end
   end
 
+  describe ".clear_token_for_account", redis: true do
+    subject { described_class.clear_token_for_account(account["id"]) }
+    before { Resque.redis.rpush("cme-token-123", "123abc") }
+
+    it "removes the token from redis" do
+      subject
+      expect(Resque.redis.rpop("cme-token-123")).to be_nil
+    end
+
+    context "when there is a resque error" do
+      before { raise_redis_connection_error(:del) }
+
+      it "should notify honeybadger and return an error" do
+        expect_errors_and_notify_honeybadger
+      end
+    end
+  end
+
   describe ".key_name", redis: true do
-    subject { klass.key_name(account["id"]) }
+    subject { described_class.key_name(account["id"]) }
 
     it { expect(subject).to eq "cme-token-123" }
   end


### PR DESCRIPTION
story: [OME-437](https://linear.app/molecule/issue/OME-437/handle-invalid-x-cme-token-response-by-clearing-token-and-initiating)

When CME returns a TradeCaptureReportRequestAck with "x-cme-token is no longer valid", detect the message, clear the stale token from Redis, and log a warning instead of notifying Honeybadger or setting body_has_errors. This allows the next fetch cycle to fall back to a new_client_request (type 1) and initiate a fresh subscription automatically.

Made-with: Cursor