### PR TITLE
[OME-644] CME trade-capture messages can be silently lost if the ingestion listener restarts mid-poll

### DIFF
--- a/lib/cme_fix_listener/history_response_handler.rb
+++ b/lib/cme_fix_listener/history_response_handler.rb
@@ -3,6 +3,13 @@
 module CmeFixListener
   # Handles CME responses in a manor suitable for history requests
   class HistoryResponseHandler < ResponseHandler
+    # History pagination keeps the token in memory only; do not advance the live
+    # poll cursor in Redis.
+    def commit_parsed_response(parsed_headers, parsed_body, raw_headers)
+      handle_headers(parsed_headers, raw_headers)
+      handle_body(parsed_body)
+    end
+
     def handle_headers(parsed_headers, _raw_headers)
       Logging.logger.debug { parsed_headers }
       @token = parsed_headers["token"]

--- a/lib/cme_fix_listener/response_handler.rb
+++ b/lib/cme_fix_listener/response_handler.rb
@@ -20,6 +20,7 @@ module CmeFixListener
       @account_id = account["id"]
       @body_has_errors = false
       @token = nil
+      @invalid_token_cleared = false
     end
 
     def experiencing_problems?
@@ -28,9 +29,8 @@ module CmeFixListener
 
     def handle_cme_response(cme_response)
       parsed_headers = parse_headers(cme_response.headers)
-      handle_headers(parsed_headers, cme_response.headers)
       parsed_body = parse_body(cme_response.body)
-      handle_body(parsed_body)
+      commit_parsed_response(parsed_headers, parsed_body, cme_response.headers)
     end
 
     def parse_headers(headers)
@@ -39,6 +39,20 @@ module CmeFixListener
         "account_id" => @account_id,
         "created_at" => headers["date"]
       }
+    end
+
+    # Atomically advances the CME poll cursor and enqueues the trade batch so a
+    # mid-poll crash cannot leave the cursor advanced without the batch queued.
+    def commit_parsed_response(parsed_headers, parsed_body, raw_headers)
+      return if @invalid_token_cleared
+
+      if parsed_headers["token"].blank?
+        notify_admins_of_error(TokenNotFound, header_error_message, header_error_context(raw_headers, parsed_headers))
+        handle_body(parsed_body)
+      else
+        message = parsed_body.blank? ? nil : parsed_body.to_json
+        CmeFixListener::ResqueManager.persist_token_and_enqueue(@account_id, parsed_headers["token"], message)
+      end
     end
 
     def handle_headers(parsed_headers, raw_headers)
@@ -65,6 +79,7 @@ module CmeFixListener
       if invalid_token?(parser.request_acknowledgement_text.downcase)
         Logging.logger.warn { "Invalid x-cme-token for account #{account_id}. Clearing token to initiate new subscription." }
         CmeFixListener::TokenManager.clear_token_for_account(@account_id)
+        @invalid_token_cleared = true
       else
         notify_admins_of_error(CmeResponseHasErrors, body_error_message, body_error_context(parser, body))
         @body_has_errors = true

--- a/lib/cme_fix_listener/resque_manager.rb
+++ b/lib/cme_fix_listener/resque_manager.rb
@@ -8,6 +8,16 @@ module CmeFixListener
       push(enqueue_item(account_id, msg))
     end
 
+    # Persist the CME poll cursor (token) and optionally enqueue the trade batch
+    # in a single Redis MULTI/EXEC so a crash cannot advance the cursor without
+    # durably queuing the messages from that poll.
+    def self.persist_token_and_enqueue(account_id, token, msg = nil)
+      Resque.redis.multi do
+        Resque.redis.rpush(TokenManager.key_name(account_id), token)
+        push(enqueue_item(account_id, msg)) if msg.present?
+      end
+    end
+
     def self.enqueue_item(account_id, msg)
       {
         "class" => ENV["REDIS_CLASS_NAME"],

--- a/spec/cme_fix_listener/response_handler_spec.rb
+++ b/spec/cme_fix_listener/response_handler_spec.rb
@@ -13,16 +13,60 @@ describe CmeFixListener::ResponseHandler do
   describe "#handle_cme_response" do
     let(:cme_response) { double(body: body, headers: headers) }
     let(:body) { "body" }
-    let(:headers) { "headers" }
+    let(:headers) { { "x-cme-token" => "tok-1", "date" => "Mon, 01 Jan 2024" } }
+    let(:parsed_body) { [{ "trade" => 1 }] }
 
     subject { instance.handle_cme_response(cme_response) }
 
-    it "should make the appropriate method calls" do
-      expect(instance).to receive(:parse_headers).with(headers).and_return("123")
-      expect(instance).to receive(:handle_headers).with("123", headers).and_return(nil)
-      expect(instance).to receive(:parse_body).with(body).and_return("abc")
-      expect(instance).to receive(:handle_body).with("abc").and_return(nil)
+    before do
+      allow_any_instance_of(parser_klass).to receive(:request_acknowledgement_text).and_return(nil)
+      allow_any_instance_of(parser_klass).to receive(:parse_fixml).and_return(parsed_body)
+    end
+
+    it "persists the token and trade batch together after parsing" do
+      expect(resque_klass).to receive(:persist_token_and_enqueue).with(123, "tok-1", parsed_body.to_json)
+      expect(token_manager_klass).not_to receive(:add_token_for_account)
+      expect(resque_klass).not_to receive(:enqueue)
       subject
+    end
+
+    context "when a crash occurs after the CME response is received but before Redis commit" do
+      before do
+        allow(resque_klass).to receive(:persist_token_and_enqueue).and_raise(Redis::CannotConnectError)
+      end
+
+      it "does not leave the poll cursor advanced without the batch queued" do
+        expect(token_manager_klass).not_to receive(:add_token_for_account)
+        expect(resque_klass).not_to receive(:enqueue)
+        expect { subject }.to raise_error(Redis::CannotConnectError)
+      end
+    end
+
+    context "when the response has an invalid token error" do
+      before do
+        allow_any_instance_of(parser_klass).to receive(:request_acknowledgement_text)
+          .and_return("x-cme-token is no longer valid. Please initiate a new subscription")
+        allow(token_manager_klass).to receive(:clear_token_for_account)
+      end
+
+      it "clears the token and does not re-advance the cursor" do
+        expect(token_manager_klass).to receive(:clear_token_for_account).with(123)
+        expect(resque_klass).not_to receive(:persist_token_and_enqueue)
+        expect(resque_klass).not_to receive(:enqueue)
+        subject
+      end
+    end
+
+    context "when the token is missing" do
+      let(:headers) { { "date" => "Mon, 01 Jan 2024" } }
+
+      before { allow(Honeybadger).to receive(:notify) }
+
+      it "notifies and still enqueues the body without advancing a token" do
+        expect(resque_klass).to receive(:enqueue).with(123, parsed_body.to_json)
+        expect(resque_klass).not_to receive(:persist_token_and_enqueue)
+        subject
+      end
     end
   end
 
@@ -168,6 +212,31 @@ describe CmeFixListener::ResponseHandler do
 
       it "should publish to resque" do
         expect(resque_klass).to receive(:enqueue).with(123, parsed_body.to_json)
+        subject
+      end
+    end
+  end
+
+  describe "#commit_parsed_response" do
+    let(:raw_headers) { { "x-cme-token" => "tok-1" } }
+    let(:parsed_headers) { { "token" => "tok-1", "account_id" => 123 } }
+
+    subject { instance.commit_parsed_response(parsed_headers, parsed_body, raw_headers) }
+
+    context "when the parsed body is blank" do
+      let(:parsed_body) { nil }
+
+      it "advances the token without enqueueing" do
+        expect(resque_klass).to receive(:persist_token_and_enqueue).with(123, "tok-1", nil)
+        subject
+      end
+    end
+
+    context "when the parsed body is present" do
+      let(:parsed_body) { [{ "qty" => 47 }] }
+
+      it "advances the token and enqueues the batch together" do
+        expect(resque_klass).to receive(:persist_token_and_enqueue).with(123, "tok-1", parsed_body.to_json)
         subject
       end
     end

--- a/spec/cme_fix_listener/resque_manager_spec.rb
+++ b/spec/cme_fix_listener/resque_manager_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe CmeFixListener::ResqueManager do
+  let(:account_id) { 123 }
+  let(:token) { "cme-token-abc" }
+  let(:msg) { [{ "tradeId" => "1" }].to_json }
+  let(:queue_name) { "critical" }
+  let(:class_name) { "CmeTrdCaptRptMsg" }
+
+  around do |example|
+    old_queue = ENV["REDIS_QUEUE_NAME"]
+    old_class = ENV["REDIS_CLASS_NAME"]
+    ENV["REDIS_QUEUE_NAME"] = queue_name
+    ENV["REDIS_CLASS_NAME"] = class_name
+    example.run
+  ensure
+    ENV["REDIS_QUEUE_NAME"] = old_queue
+    ENV["REDIS_CLASS_NAME"] = old_class
+  end
+
+  describe ".persist_token_and_enqueue" do
+    it "writes the token and queue item inside a single Redis MULTI" do
+      expect(Resque.redis).to receive(:multi).and_yield.and_return([])
+      expect(Resque.redis).to receive(:rpush).with("cme-token-123", token).ordered
+      expect(Resque.redis).to receive(:sadd).with("queues", queue_name).ordered
+      expect(Resque.redis).to receive(:rpush).with(
+        "queue:#{queue_name}",
+        described_class.enqueue_item(account_id, msg)
+      ).ordered
+
+      described_class.persist_token_and_enqueue(account_id, token, msg)
+    end
+
+    it "advances the token without enqueueing when the message is blank" do
+      expect(Resque.redis).to receive(:multi).and_yield.and_return([])
+      expect(Resque.redis).to receive(:rpush).once.with("cme-token-123", token)
+      expect(Resque.redis).not_to receive(:sadd)
+
+      described_class.persist_token_and_enqueue(account_id, token, nil)
+    end
+
+    context "with a real Redis MULTI/EXEC", redis: true do
+      before { Resque.redis.redis.flushall }
+      after { Resque.redis.redis.flushall }
+
+      it "commits the token and trade batch together" do
+        described_class.persist_token_and_enqueue(account_id, token, msg)
+
+        expect(Resque.redis.rpop("cme-token-123")).to eq token
+        expect(Resque.redis.smembers("queues")).to include(queue_name)
+        expect(Resque.redis.rpop("queue:#{queue_name}")).to eq described_class.enqueue_item(account_id, msg)
+      end
+
+      it "does not advance the token when work fails inside MULTI before EXEC" do
+        call_count = 0
+        allow(Resque.redis).to receive(:rpush).and_wrap_original do |original, *args|
+          call_count += 1
+          raise Redis::CannotConnectError if call_count > 1
+          original.call(*args)
+        end
+
+        expect {
+          described_class.persist_token_and_enqueue(account_id, token, msg)
+        }.to raise_error(Redis::CannotConnectError)
+
+        expect(Resque.redis.lindex("cme-token-123", 0)).to be_nil
+        expect(Resque.redis.llen("queue:#{queue_name}")).to eq 0
+      end
+    end
+  end
+
+  describe ".enqueue" do
+    it "pushes the item onto the configured queue" do
+      expect(Resque.redis).to receive(:sadd).with("queues", queue_name)
+      expect(Resque.redis).to receive(:rpush).with(
+        "queue:#{queue_name}",
+        described_class.enqueue_item(account_id, msg)
+      )
+
+      described_class.enqueue(account_id, msg)
+    end
+  end
+end


### PR DESCRIPTION
story: [OME-644](https://linear.app/molecule/issue/OME-644/cme-trade-capture-messages-can-be-silently-lost-if-the-ingestion)

Prevent silent trade loss when the listener restarts mid-poll by writing the CME token and Resque batch in a single Redis MULTI/EXEC.